### PR TITLE
feat:追加・完了・削除・戻す機能作成

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,8 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
+  <!-- <link rel="manifest" href="/manifest.json" crossorigin="use-credentials"> -->
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/Todo.tsx
+++ b/src/Todo.tsx
@@ -1,24 +1,59 @@
-import { useState } from 'react';
+import { useState, ChangeEvent } from 'react';
 import './App.css';
 
 export const Todo = () => {
-  const [incompleteTodos, setincompleteTodos] = useState(["TODOです1", "TODOです2"]);
-  const [completeTodos, setCompleteTodos] = useState(["TODOでした1", "TODOでした2"]);
+  const [todoText, setTodoText] = useState<string>("");
+  const [incompleteTodos, setIncompleteTodos] = useState<string[]>([]);
+  const [completeTodos, setCompleteTodos] = useState<string[]>([]);
+
+  const onChangeTodoText = (event: ChangeEvent<HTMLInputElement>) => setTodoText(event.target.value);
+
+  const onClickAdd = () => {
+    if (todoText === "") return;
+    const newTodos = [...incompleteTodos, todoText];
+    setIncompleteTodos(newTodos);
+    setTodoText("");
+  };
+
+  const onClickDelete = (index: number) => {
+    const newTodos = [...incompleteTodos];
+    newTodos.splice(index, 1);
+    setIncompleteTodos(newTodos);
+  };
+
+  const onClickComplete = (index: number) => {
+    const newIncompleteTodos = [...incompleteTodos];
+    newIncompleteTodos.splice(index, 1);
+
+    const newCompleteTodos = [...completeTodos, incompleteTodos[index]];
+    setIncompleteTodos(newIncompleteTodos);
+    setCompleteTodos(newCompleteTodos);
+  };
+
+  const onClickBack = (index: number) => {
+    const newCompleteTodos = [...completeTodos];
+    newCompleteTodos.splice(index, 1);
+
+    const newIncompleteTodos = [...incompleteTodos, completeTodos[index]];
+    setCompleteTodos(newCompleteTodos);
+    setIncompleteTodos(newIncompleteTodos);
+  };
+
   return (
     <>
     <div>
-      <input placeholder="TODOを入力" />
-      <button>追加</button>
+      <input placeholder="TODOを入力" value={todoText} onChange={onChangeTodoText} />
+      <button onClick={onClickAdd}>追加</button>
       </div>
       <div>
         <p>未完了のTODO</p>
         <ul>
-          {incompleteTodos.map((todo) => (
+          {incompleteTodos.map((todo, index) => (
             <li key={todo}>
               <div>
                 <p>{todo}</p>
-                <button>完了</button>
-                <button>削除</button>
+                <button onClick={() => onClickComplete(index)}>完了</button>
+                <button onClick={() => onClickDelete(index)}>削除</button>
               </div>
             </li>
           ))}
@@ -27,11 +62,11 @@ export const Todo = () => {
       <div>
         <p>完了のTODO</p>
         <ul>
-          {completeTodos.map((todo) => (
+          {completeTodos.map((todo, index) => (
             <li key={todo}>
               <div>
                 <p>{todo}</p>
-                <button>戻す</button>
+                <button onClick={() => onClickBack(index)}>戻す</button>
               </div>
             </li>
           ))}


### PR DESCRIPTION
# TODOアプリの機能を実装

## 説明
このプルリクエストでは、TODOアプリの機能を実装しました。
- 新しいTODOを入力フィールドで入力して追加ボタンをクリック
- 未完了のTODOの完了ボタンをクリック
- 未完了のTODOの削除ボタンをクリック
- 完了のTODOの戻すボタンをクリック

## チェックリスト
- [x] 追加したTODOリストが未完了のTODOに表示されるか
- [x] 完了ボタンをクリックしたTODOが完了のTODOに表示されるか
- [x] 削除ボタンをクリックしたTODOが未完了のTODOから削除されるか
- [x] 戻すボタンをクリックしたTODOが未完了のTODOに表示されるか

## 追加の注意点
コードをレビューし、実装に関するフィードバックをお願いします。