### PR TITLE
refactor:機能ごとに関数をコンポーネント化

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-transform-private-property-in-object": "^7.24.7"
   }
 }

--- a/src/Todo.tsx
+++ b/src/Todo.tsx
@@ -1,5 +1,8 @@
 import { useState, ChangeEvent } from 'react';
 import './App.css';
+import { InputTodo } from './components/InputTodo';
+import { IncompleteTodos } from './components/IncompleteTodos';
+import { CompleteTodos } from './components/CompleteTodos';
 
 export const Todo = () => {
   const [todoText, setTodoText] = useState<string>("");
@@ -39,41 +42,27 @@ export const Todo = () => {
     setIncompleteTodos(newIncompleteTodos);
   };
 
+  const isMaxLimitIncompleteTodos = incompleteTodos.length >= 5;
+
   return (
     <>
-    <div>
-      <input placeholder="TODOを入力" value={todoText} onChange={onChangeTodoText} />
-      <button onClick={onClickAdd}>追加</button>
-      </div>
-      <div>
-        <p>未完了のTODO</p>
-        <ul>
-          {incompleteTodos.map((todo, index) => (
-            <li key={todo}>
-              <div>
-                <p>{todo}</p>
-                <button onClick={() => onClickComplete(index)}>完了</button>
-                <button onClick={() => onClickDelete(index)}>削除</button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <p>完了のTODO</p>
-        <ul>
-          {completeTodos.map((todo, index) => (
-            <li key={todo}>
-              <div>
-                <p>{todo}</p>
-                <button onClick={() => onClickBack(index)}>戻す</button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <InputTodo
+        todoText={todoText}
+        onChange={onChangeTodoText}
+        onClick={onClickAdd}
+        disabled={isMaxLimitIncompleteTodos}
+      />
+      {isMaxLimitIncompleteTodos && (
+        <p style={{ color: "red" }}>登録できるTODOは5個までです</p>
+      )}
+      <IncompleteTodos
+        todos={incompleteTodos}
+        onClickComplete={onClickComplete}
+        onClickDelete={onClickDelete}
+      />
+      <CompleteTodos todos={completeTodos} onClickBack={onClickBack} />
     </>
   );
 }
-  
+
 

--- a/src/components/CompleteTodos.tsx
+++ b/src/components/CompleteTodos.tsx
@@ -1,0 +1,25 @@
+import { FC } from "react";
+
+type TodoType = {
+  todos: string[];
+  onClickBack: (index: number) => void;
+}
+
+export const CompleteTodos: FC<TodoType> = (props) => {
+  const { todos, onClickBack } = props;
+  return (
+    <div>
+      <p>完了のTODO</p>
+      <ul>
+        {todos.map((todo, index) => (
+          <li key={todo}>
+            <div>
+              <p>{todo}</p>
+              <button onClick={() => onClickBack(index)}>戻す</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/IncompleteTodos.tsx
+++ b/src/components/IncompleteTodos.tsx
@@ -1,0 +1,27 @@
+import { FC } from "react";
+
+type TodoType = {
+  todos: string[];
+  onClickComplete: (index: number) => void;
+  onClickDelete: (index: number) => void;
+}
+
+export const IncompleteTodos: FC<TodoType> = (props) => {
+  const { todos, onClickComplete, onClickDelete } = props;
+  return (
+    <div>
+      <p>未完了のTODO</p>
+      <ul>
+        {todos.map((todo, index) => (
+          <li key={todo}>
+            <div>
+              <p>{todo}</p>
+              <button onClick={() => onClickComplete(index)}>完了</button>
+              <button onClick={() => onClickDelete(index)}>削除</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -1,0 +1,18 @@
+import { FC, ChangeEvent, MouseEventHandler } from "react";
+
+type TodoType = {
+  todoText: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClick: MouseEventHandler;
+  disabled: boolean;
+}
+
+export const InputTodo: FC<TodoType> = (props) => {
+  const { todoText, onChange, onClick, disabled } = props;
+  return (
+    <div>
+      <input disabled={disabled} placeholder="TODOを入力" value={todoText} onChange={onChange} />
+      <button disabled={disabled} onClick={onClick}>追加</button>
+    </div>
+  );
+};


### PR DESCRIPTION
# TODOアプリのコンポーネント化を実装

## 説明
このプルリクエストでは、TODOアプリのコンポーネント化を実装しました。
- TODOを入力するエリア
- 未完了のTODOを表示するエリア
- 完了のTODOを表示するエリア

## チェックリスト
- [x] TODOを入力して追加する関数のコンポーネント
- [x] 未完了のTODOを表示して完了と削除する関数のコンポーネント
- [x] 完了のTODOを表示して戻す関数のコンポーネント

## 追加の注意点
コードをレビューし、実装に関するフィードバックをお願いします。